### PR TITLE
Add support for FLOKI and BONK

### DIFF
--- a/src/currencies.js
+++ b/src/currencies.js
@@ -1515,6 +1515,16 @@ var CURRENCIES = [
     symbol: 'near',
     validator: NEARValidator,
   },
+  {
+    name: 'Bonk',
+    symbol: 'bonk',
+    validator: SOLValidator,
+  },
+  {
+    name: 'Floki',
+    symbol: 'floki',
+    validator: ETHValidator,
+  },
 ];
 
 module.exports = {


### PR DESCRIPTION
Two new tokens were added with their respective address validators:

```
  {
    name: 'Bonk',
    symbol: 'bonk',
    validator: SOLValidator,
  },
  {
    name: 'Floki',
    symbol: 'floki',
    validator: ETHValidator,
  }
```